### PR TITLE
Stops cluster autoscaler failing completely during deployments

### DIFF
--- a/lib/scaleDown.js
+++ b/lib/scaleDown.js
@@ -11,7 +11,12 @@ module.exports = data => {
     const instanceConstraints = R.map(dataUtils.instanceToConstraints, data.containerInstances);
     for(let i = 0; i < removeableInstances.length; i++) {
         if(!removeableInstances[i]) continue;
-        const tasks = R.map(task => dataUtils.taskToDefinition(data.taskDefinitions, task), dataUtils.instanceTasks(data.containerInstances[i])(data.tasks));
+        let tasks;
+        try {
+            tasks = R.map(task => dataUtils.taskToDefinition(data.taskDefinitions, task), dataUtils.instanceTasks(data.containerInstances[i])(data.tasks));
+        } catch(e) {
+            continue;
+        }
         const taskConstraints = R.map(dataUtils.taskToConstraints, tasks);
         if(binpack(R.remove(i, 1, instanceConstraints), taskConstraints)) {
             return data.containerInstances[i].ec2InstanceId;

--- a/test/scaleDown.js
+++ b/test/scaleDown.js
@@ -96,6 +96,29 @@ describe('scaleDown', () => {
             ]
         }).should.be.equal('i-123');
     });
+    it('should not remove an instance with container definitions that can\'t be found', () => {
+        scaleDown({
+            containerInstances: [
+                instance('i-124', 100, 100, 'abc', '1'),
+                instance('i-123', 0, 0, 'abd', '1')
+            ],
+            ec2Instances: [
+                ec2('i-123', shouldDie),
+                ec2('i-124', shouldDie)
+            ],
+            taskDefinitions: [{
+                taskDefinitionArn: 'def',
+                containerDefinitions: [{
+                    memory: 100,
+                    cpu: 100
+                }]
+            }],
+            tasks: [
+                task('abc', 'def'),
+                task('abd', 'hij')
+            ]
+        }).should.be.false();
+    });
     it('should remove an aging instance and put containers in a newer instance', () => {
         scaleDown({
             containerInstances: [


### PR DESCRIPTION
During deployments of a new ecs service version, it apears possible that
not all taskDefs are correctly returned.

This can then fail and leave
the cluster in a broken state.